### PR TITLE
Fix live render and update prompt editor layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,8 +8,9 @@
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 </head>
-<body class="bg-gray-900 text-white h-full flex items-center justify-center p-4">
-  <div x-data="promptStudio()" class="w-full max-w-3xl bg-gray-800 rounded-lg shadow-lg p-6 space-y-6">
+<body class="bg-gray-900 text-white h-full p-4">
+  <div x-data="promptStudio()" class="w-full max-w-5xl mx-auto bg-gray-800 rounded-lg shadow-lg p-6 flex flex-col md:flex-row gap-6">
+    <div class="flex-1 space-y-6">
     <h1 class="text-2xl font-bold text-center">Prompt Template Studio</h1>
 
     <!-- Prompt Sections -->
@@ -17,9 +18,8 @@
       <template x-for="(section, idx) in sections" :key="idx">
         <div class="mb-4 p-3 bg-gray-700 rounded space-y-2">
           <div class="flex space-x-2">
-            <input x-model="section.name" placeholder="Name" class="w-1/4 p-1 bg-gray-900 rounded focus:outline-none">
-            <input x-model="section.startTag" placeholder="Start tag" class="w-1/4 p-1 bg-gray-900 rounded focus:outline-none">
-            <input x-model="section.endTag" placeholder="End tag" class="w-1/4 p-1 bg-gray-900 rounded focus:outline-none">
+            <input x-model="section.startTag" placeholder="Begin tag" class="w-1/3 p-1 bg-gray-900 rounded focus:outline-none">
+            <input x-model="section.endTag" placeholder="End tag" class="w-1/3 p-1 bg-gray-900 rounded focus:outline-none">
             <button @click="removeSection(idx)" class="px-2 bg-red-600 rounded">Remove</button>
           </div>
           <textarea x-model="section.content" rows="3" class="w-full p-2 bg-gray-900 rounded focus:outline-none" placeholder="Section content"></textarea>
@@ -41,8 +41,9 @@
       <button @click="addEntry" class="px-3 py-1 bg-blue-600 rounded">Add Entry</button>
     </div>
 
+    </div>
     <!-- Live Render Output -->
-    <div>
+    <div class="flex-1">
       <h2 class="font-semibold mb-2">Live Render</h2>
       <div class="bg-gray-900 rounded p-3 min-h-[4rem] prose max-w-none" x-html="markdownRendered()"></div>
     </div>
@@ -52,14 +53,14 @@
   function promptStudio(){
     return {
       sections:[
-        {name:'MAIN', startTag:'', endTag:'', content:'You are chatting with {{user}} about {{topic}}.'}
+        {startTag:'', endTag:'', content:'You are chatting with {{user}} about {{topic}}.'}
       ],
       entries:[
         {key:'user', value:'Adrian'},
         {key:'topic', value:'AI'}
       ],
       addSection(){
-        this.sections.push({name:'SECTION', startTag:'[SECTION]', endTag:'[/SECTION]', content:''});
+        this.sections.push({startTag:'[SECTION]', endTag:'[/SECTION]', content:''});
       },
       removeSection(i){
         this.sections.splice(i,1);
@@ -80,9 +81,10 @@
         }
         return out;
       },
-      markdownRendered(){
-        return marked.parse(this.rendered());
-      }
+        markdownRendered(){
+          const text = this.rendered();
+          return window.marked ? marked.parse(text) : text.replace(/\n/g, "<br>");
+        }
     }
   }
   </script>


### PR DESCRIPTION
## Summary
- improve layout so editor and live output are side‑by‑side
- drop the section `name` field and just keep begin and end tags
- make live render resilient if the markdown library fails to load

## Testing
- `true`