### PR TITLE
Improve section tag UX

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,31 +15,31 @@
 
     <!-- Prompt Sections -->
     <div>
-      <template x-for="(section, idx) in sections" :key="idx">
-        <div class="mb-4 p-3 bg-gray-700 rounded space-y-2">
-          <div class="flex space-x-2">
-            <input x-model="section.startTag" placeholder="Begin tag" class="w-1/3 p-1 bg-gray-900 rounded focus:outline-none">
-            <input x-model="section.endTag" placeholder="End tag" class="w-1/3 p-1 bg-gray-900 rounded focus:outline-none">
-            <button @click="removeSection(idx)" class="px-2 bg-red-600 rounded">Remove</button>
+        <template x-for="(section, idx) in sections" :key="idx">
+          <div class="mb-4 p-3 bg-gray-700 rounded space-y-2 transition-all" x-transition>
+            <div class="flex space-x-2">
+              <input x-model="section.startTag" @input="syncEndTag(section)" placeholder="Begin tag" class="w-1/3 p-1 bg-gray-900 rounded focus:outline-none">
+              <input x-model="section.endTag" placeholder="End tag" class="w-1/3 p-1 bg-gray-900 rounded focus:outline-none">
+              <button @click="removeSection(idx)" class="px-2 bg-red-600 rounded">Remove</button>
+            </div>
+            <textarea x-model="section.content" rows="3" class="w-full p-2 bg-gray-900 rounded focus:outline-none" placeholder="Section content"></textarea>
           </div>
-          <textarea x-model="section.content" rows="3" class="w-full p-2 bg-gray-900 rounded focus:outline-none" placeholder="Section content"></textarea>
-        </div>
-      </template>
-      <button @click="addSection" class="px-3 py-1 bg-blue-600 rounded">Add Section</button>
-    </div>
+        </template>
+        <button @click="addSection" class="px-3 py-1 bg-blue-600 rounded">Add Section</button>
+      </div>
 
     <!-- Key/Value Entries -->
     <div>
       <h2 class="font-semibold mb-2">Replacements</h2>
-      <template x-for="(entry, i) in entries" :key="i">
-        <div class="flex items-center mb-2 space-x-2">
-          <input type="text" x-model="entry.key" placeholder="Key" class="w-1/3 p-1 bg-gray-900 rounded focus:outline-none">
-          <input type="text" x-model="entry.value" placeholder="Value" class="flex-1 p-1 bg-gray-900 rounded focus:outline-none">
-          <button @click="removeEntry(i)" class="px-2 bg-red-600 rounded">Remove</button>
-        </div>
-      </template>
-      <button @click="addEntry" class="px-3 py-1 bg-blue-600 rounded">Add Entry</button>
-    </div>
+        <template x-for="(entry, i) in entries" :key="i">
+          <div class="flex items-center mb-2 space-x-2 transition-all" x-transition>
+            <input type="text" x-model="entry.key" placeholder="Key" class="w-1/3 p-1 bg-gray-900 rounded focus:outline-none">
+            <input type="text" x-model="entry.value" placeholder="Value" class="flex-1 p-1 bg-gray-900 rounded focus:outline-none">
+            <button @click="removeEntry(i)" class="px-2 bg-red-600 rounded">Remove</button>
+          </div>
+        </template>
+        <button @click="addEntry" class="px-3 py-1 bg-blue-600 rounded">Add Entry</button>
+      </div>
 
     </div>
     <!-- Live Render Output -->
@@ -50,17 +50,21 @@
   </div>
 
   <script>
+  function deriveEndTag(tag){
+    const match = tag.match(/\[(.+?)\]/);
+    return match ? `[/${match[1]}]` : '';
+  }
   function promptStudio(){
     return {
       sections:[
-        {startTag:'', endTag:'', content:'You are chatting with {{user}} about {{topic}}.'}
+        {startTag:'', endTag:'', autoEndTag:'', content:'You are chatting with {{user}} about {{topic}}.'}
       ],
       entries:[
         {key:'user', value:'Adrian'},
         {key:'topic', value:'AI'}
       ],
       addSection(){
-        this.sections.push({startTag:'[SECTION]', endTag:'[/SECTION]', content:''});
+        this.sections.push({startTag:'[SECTION]', endTag:'[/SECTION]', autoEndTag:'[/SECTION]', content:''});
       },
       removeSection(i){
         this.sections.splice(i,1);
@@ -71,8 +75,15 @@
       removeEntry(i){
         this.entries.splice(i,1);
       },
+      syncEndTag(section){
+        const derived = deriveEndTag(section.startTag);
+        if(section.endTag === section.autoEndTag || !section.endTag){
+          section.endTag = derived;
+        }
+        section.autoEndTag = derived;
+      },
       rendered(){
-        const template=this.sections.map(s=>`${s.startTag}\n${s.content}\n${s.endTag}`.trim()).join('\n');
+        const template=this.sections.map(s=>`${s.startTag}\n${s.content}\n${s.endTag}\n`).join('');
         let out=template;
         for(const {key,value} of this.entries){
           if(!key) continue;


### PR DESCRIPTION
## Summary
- auto-fill end tag based on start tag with ability to override
- add newline after each section and after tags when rendering
- add transition effects for section and entry lists

## Testing
- `npm --version`