### PR TITLE
Implement dark theme with icon buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ A lightweight client-side web app for building and previewing prompt templates f
 
 ## Usage
 
-Open `index.html` in a browser. No build step or server is required.
+Run `npm run build` to generate `dist/output.css`, then open `index.html` in a browser. The site is entirely static and can be hosted on GitHub Pages.
 
 Feel free to customize the default template and styling.

--- a/index.html
+++ b/index.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
-<html lang="en" class="h-full">
+<html lang="en" class="h-full dark">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>promptbin</title>
-  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="dist/output.css" rel="stylesheet">
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
-<body class="bg-gray-900 text-white h-full p-4">
+<body class="bg-gray-900 text-gray-100 h-full p-4">
   <div x-data="promptStudio()" class="w-full max-w-5xl mx-auto bg-gray-800 rounded-lg shadow-lg p-6 flex flex-col md:flex-row gap-6">
     <div class="flex-1 space-y-6">
     <h1 class="text-2xl font-bold text-center">promptbin</h1>
@@ -17,7 +17,12 @@
       <h2 class="font-semibold mb-2">Saved Prompts</h2>
       <div class="flex mb-2 space-x-2">
         <input type="text" x-model="saveName" placeholder="Prompt name" class="flex-1 p-1 bg-gray-900 rounded focus:outline-none">
-        <button @click="savePrompt" class="px-2 bg-green-600 rounded">Save</button>
+        <icon-button title="Save prompt" @click="savePrompt" class="text-accent">
+          <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path d="M5 3a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2V7l-4-4H5z"/>
+            <path d="M9 12v3h2v-3h3l-4-4-4 4h3z" fill="currentColor"/>
+          </svg>
+        </icon-button>
       </div>
       <div class="flex mb-2 space-x-2">
         <select x-model="selectedPrompt" @change="loadPrompt(selectedPrompt)" class="flex-1 p-1 bg-gray-900 rounded focus:outline-none">
@@ -26,7 +31,11 @@
             <option :value="name" x-text="name"></option>
           </template>
         </select>
-        <button @click="deletePrompt(selectedPrompt)" :disabled="!selectedPrompt" class="px-2 bg-red-600 rounded">Delete</button>
+        <icon-button title="Delete prompt" @click="deletePrompt(selectedPrompt)" :disabled="!selectedPrompt" class="text-red-500">
+          <svg class="h-5 w-5" viewBox="0 0 20 20" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg" stroke-width="2">
+            <path d="M6 6l8 8M6 14L14 6" stroke-linecap="round"/>
+          </svg>
+        </icon-button>
       </div>
     </div>
 
@@ -37,12 +46,20 @@
             <div class="flex space-x-2">
               <input x-model="section.startTag" @input="syncEndTag(section)" placeholder="Begin tag" class="w-1/3 p-1 bg-gray-900 rounded focus:outline-none">
               <input x-model="section.endTag" placeholder="End tag" class="w-1/3 p-1 bg-gray-900 rounded focus:outline-none">
-              <button @click="removeSection(idx)" class="px-2 bg-red-600 rounded">Remove</button>
+              <icon-button title="Remove section" @click="removeSection(idx)" class="text-red-500">
+                <svg class="h-5 w-5" viewBox="0 0 20 20" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg" stroke-width="2">
+                  <path d="M5 10h10" stroke-linecap="round"/>
+                </svg>
+              </icon-button>
             </div>
             <textarea x-model="section.content" rows="3" class="w-full p-2 bg-gray-900 rounded focus:outline-none" placeholder="Section content"></textarea>
           </div>
         </template>
-        <button @click="addSection" class="px-3 py-1 bg-blue-600 rounded">Add Section</button>
+        <icon-button title="Add section" @click="addSection" class="text-accent">
+          <svg class="h-5 w-5" viewBox="0 0 20 20" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg" stroke-width="2">
+            <path d="M10 5v10M5 10h10" stroke-linecap="round"/>
+          </svg>
+        </icon-button>
       </div>
 
     <!-- Key/Value Entries -->
@@ -52,10 +69,18 @@
           <div class="flex items-center mb-2 space-x-2 transition-all" x-transition>
             <input type="text" x-model="entry.key" placeholder="Key" class="w-1/3 p-1 bg-gray-900 rounded focus:outline-none">
             <input type="text" x-model="entry.value" placeholder="Value" class="flex-1 p-1 bg-gray-900 rounded focus:outline-none">
-            <button @click="removeEntry(i)" class="px-2 bg-red-600 rounded">Remove</button>
+            <icon-button title="Remove entry" @click="removeEntry(i)" class="text-red-500">
+              <svg class="h-5 w-5" viewBox="0 0 20 20" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg" stroke-width="2">
+                <path d="M5 10h10" stroke-linecap="round"/>
+              </svg>
+            </icon-button>
           </div>
         </template>
-        <button @click="addEntry" class="px-3 py-1 bg-blue-600 rounded">Add Entry</button>
+        <icon-button title="Add entry" @click="addEntry" class="text-accent">
+          <svg class="h-5 w-5" viewBox="0 0 20 20" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg" stroke-width="2">
+            <path d="M10 5v10M5 10h10" stroke-linecap="round"/>
+          </svg>
+        </icon-button>
       </div>
 
 
@@ -64,7 +89,12 @@
     <div class="flex-1">
       <div class="flex items-center justify-between mb-2">
         <h2 class="font-semibold">Live Render</h2>
-        <button @click="copyRender" class="px-2 bg-blue-600 rounded">Copy</button>
+        <icon-button title="Copy output" @click="copyRender" class="text-accent">
+          <svg class="h-5 w-5" viewBox="0 0 20 20" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg" stroke-width="2">
+            <rect x="4" y="4" width="9" height="12" rx="2"/>
+            <path d="M7 4h8v12"/>
+          </svg>
+        </icon-button>
       </div>
       <div class="bg-gray-900 rounded p-3 min-h-[4rem] max-w-none" x-html="markdownRendered()"></div>
     </div>
@@ -162,6 +192,24 @@
       }
     }
   }
+  </script>
+  <script>
+  class IconButton extends HTMLElement {
+    connectedCallback() {
+      const title = this.getAttribute('title') || '';
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'p-2 rounded hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-accent';
+      for (const attr of Array.from(this.attributes)) {
+        if (attr.name === 'title') continue;
+        button.setAttribute(attr.name, attr.value);
+      }
+      button.innerHTML = this.innerHTML + (title ? `<span class="sr-only">${title}</span>` : '');
+      if (title) button.title = title;
+      this.replaceChildren(button);
+    }
+  }
+  customElements.define('icon-button', IconButton);
   </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "promptbin",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "tailwindcss -c tailwind.config.js -i src/input.css -o dist/output.css --minify"
+  },
+  "devDependencies": {
+    "tailwindcss": "^3.3.0"
+  }
+}

--- a/src/input.css
+++ b/src/input.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  darkMode: 'class',
+  theme: {
+    extend: {
+      colors: {
+        accent: {
+          DEFAULT: '#5A67D8',
+          light: '#7F9CF5',
+          dark: '#434190'
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Tailwind build configuration and accent palette
- make `IconButton` web component
- swap text buttons for icon buttons with accessible labels
- refactor styling to use dark theme classes
- document build step with npm

## Testing
- `npm run build` *(fails: tailwindcss not found)*