### PR TITLE
Add token count display

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A lightweight client-side web app for building and previewing prompt templates f
 - Icon-based buttons for a compact interface.
 - Reorder sections via drag and drop.
 - Animated interactions with feedback when copying the rendered prompt.
+- Displays estimated token count for the rendered prompt.
 - Separate settings page to manage preferences.
 
 ## Usage

--- a/index.html
+++ b/index.html
@@ -83,7 +83,8 @@
     <div class="flex-1">
       <div class="flex items-center justify-between mb-2">
         <h2 class="font-semibold">Live Render</h2>
-        <div class="flex items-center">
+        <div class="flex items-center space-x-2">
+          <span class="text-xs text-gray-400" x-text="'Tokens: ' + tokenCount()"></span>
           <button @click="copyRender" class="px-2 bg-gray-700 rounded" aria-label="Copy"><i class="fa-solid fa-copy"></i></button>
           <span x-show="copied" x-transition class="text-green-400 text-xs ml-2">Copied!</span>
         </div>
@@ -162,6 +163,13 @@
       },
       markdownRendered(){
         return this.rendered().replace(/\n/g, "<br>");
+      },
+      estimateTokens(text){
+        if(!text) return 0;
+        return text.trim().split(/\s+/).filter(Boolean).length;
+      },
+      tokenCount(){
+        return this.estimateTokens(this.rendered());
       },
       loadSaved(){
         const data = localStorage.getItem('savedPrompts');


### PR DESCRIPTION
## Summary
- document token count feature
- add token count output next to Copy button
- implement estimateTokens and tokenCount helpers for prompt analytics

## Testing
- `npm test` *(fails: package.json missing)*