### PR TITLE
Add collapsible sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,14 +66,19 @@
     <div>
         <div x-ref="sectionsContainer">
           <template x-for="(section, idx) in sections" :key="idx">
-            <div x-show="!section.removing" class="mb-4 p-3 bg-neutral-800 rounded space-y-2 transition-all" x-transition.opacity.scale.duration.300 :class="theme === 'light' ? 'bg-neutral-100 text-black' : 'bg-neutral-800'">
+            <div x-show="!section.removing" class="mb-4 p-3 bg-neutral-800 rounded transition-all space-y-2" x-transition.opacity.scale.duration.300 :class="theme === 'light' ? 'bg-neutral-100 text-black' : 'bg-neutral-800'">
               <div class="flex space-x-2 items-center">
                 <span class="cursor-move drag-handle text-neutral-400"><i class="fa-solid fa-up-down-left-right"></i></span>
+                <button @click="section.collapsed = !section.collapsed" class="text-neutral-400 focus:outline-none">
+                  <i :class="section.collapsed ? 'fa-solid fa-chevron-down' : 'fa-solid fa-chevron-up'"></i>
+                </button>
                 <input x-model="section.startTag" @input="syncEndTag(section)" placeholder="Begin tag" class="w-1/3 p-1 bg-neutral-900 rounded focus:outline-none" :class="theme === 'light' ? 'bg-neutral-200 text-black' : 'bg-neutral-900'">
                 <input x-model="section.endTag" placeholder="End tag" class="w-1/3 p-1 bg-neutral-900 rounded focus:outline-none" :class="theme === 'light' ? 'bg-neutral-200 text-black' : 'bg-neutral-900'">
                 <button @click="removeSection(idx)" class="px-2 bg-neutral-700 rounded" :class="theme === 'light' ? 'bg-neutral-300 text-black' : 'bg-neutral-700'" aria-label="Remove section"><i class="fa-solid fa-xmark"></i></button>
               </div>
-              <textarea x-model="section.content" rows="3" class="w-full p-2 bg-neutral-900 rounded focus:outline-none" placeholder="Section content" :class="theme === 'light' ? 'bg-neutral-200 text-black' : 'bg-neutral-900'"></textarea>
+              <div x-show="!section.collapsed" x-collapse.duration.300>
+                <textarea x-model="section.content" rows="3" class="w-full p-2 mt-2 bg-neutral-900 rounded focus:outline-none" placeholder="Section content" :class="theme === 'light' ? 'bg-neutral-200 text-black' : 'bg-neutral-900'"></textarea>
+              </div>
             </div>
           </template>
         </div>
@@ -120,10 +125,10 @@
     return match ? `[/${match[1]}]` : '';
   }
   function addAnimFlag(list){
-    return list.map(item => ({...item, removing:false}));
+    return list.map(item => ({...item, removing:false, collapsed:false}));
   }
   function stripAnimFlag(list){
-    return list.map(({removing, ...rest}) => rest);
+    return list.map(({removing, collapsed, ...rest}) => rest);
   }
   function promptStudio(){
     return {
@@ -178,13 +183,13 @@
       },
       addSection(type){
         if(type && this.sectionTemplates[type]){
-          this.sections.push({...JSON.parse(JSON.stringify(this.sectionTemplates[type])), removing:false});
+          this.sections.push({...JSON.parse(JSON.stringify(this.sectionTemplates[type])), removing:false, collapsed:false});
           return;
         }
         if(this.sections.length === 0){
-          this.sections.push({...JSON.parse(JSON.stringify(this.sectionTemplates.system)), removing:false});
+          this.sections.push({...JSON.parse(JSON.stringify(this.sectionTemplates.system)), removing:false, collapsed:false});
         } else {
-          this.sections.push({startTag:'[SECTION]', endTag:'[/SECTION]', autoEndTag:'[/SECTION]', content:'', removing:false});
+          this.sections.push({startTag:'[SECTION]', endTag:'[/SECTION]', autoEndTag:'[/SECTION]', content:'', removing:false, collapsed:false});
         }
       },
       removeSection(i){


### PR DESCRIPTION
## Summary
- add expand/collapse controls to prompt sections
- remember collapse state in section objects
- omit temporary flags when saving prompts

## Testing
- `git status --short`