### PR TITLE
Add local in-browser LLM testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A lightweight client-side web app for building and previewing prompt templates f
 - Icon-based buttons for a compact interface.
 - Reorder sections via drag and drop.
 - Animated interactions with feedback when copying the rendered prompt.
+- Test prompts locally with a lightweight in-browser Llama model.
 - Displays estimated token count for the rendered prompt.
 - Built-in starter templates for code assistants and document extraction.
 - Separate settings page to manage preferences.
@@ -20,5 +21,7 @@ A lightweight client-side web app for building and previewing prompt templates f
 ## Usage
 
 Open `index.html` in a browser. No build step or server is required.
+
+Click the play button next to the token count to run your prompt through the included quantized Llama model. The first run downloads the model files, so it may take a moment.
 
 Feel free to customize the default template and styling.

--- a/index.html
+++ b/index.html
@@ -119,10 +119,19 @@
         <div class="flex items-center space-x-2">
           <span class="text-xs text-neutral-400" x-text="'Tokens: ' + tokenCount()"></span>
           <button @click="copyRender" class="px-2 bg-neutral-700 rounded" :class="theme === 'light' ? 'bg-neutral-300 text-black' : 'bg-neutral-700'" aria-label="Copy"><i class="fa-solid fa-copy"></i></button>
+          <button @click="runPrompt" class="px-2 bg-neutral-700 rounded" :class="theme === 'light' ? 'bg-neutral-300 text-black' : 'bg-neutral-700'" aria-label="Run"><i class="fa-solid fa-play"></i></button>
           <span x-show="copied" x-transition.opacity.scale.duration.300 class="text-green-400 text-xs ml-2">Copied!</span>
+          <span x-show="loadingMessage" class="text-xs text-neutral-400 ml-2 flex items-center space-x-1" x-cloak>
+            <i class="fa-solid fa-spinner animate-spin"></i>
+            <span x-text="loadingMessage"></span>
+          </span>
         </div>
       </div>
       <div class="bg-neutral-900 rounded p-3 min-h-[4rem] max-w-none" x-html="markdownRendered()" :class="theme === 'light' ? 'bg-neutral-200 text-black' : 'bg-neutral-900'"></div>
+      <div x-show="llmOutput" x-transition.opacity.duration.300 class="mt-4">
+        <h2 class="font-semibold mb-2">result</h2>
+        <div class="bg-neutral-900 rounded p-3 min-h-[4rem]" x-text="llmOutput" :class="theme === 'light' ? 'bg-neutral-200 text-black' : 'bg-neutral-900'"></div>
+      </div>
     </div>
   </div>
 
@@ -185,6 +194,9 @@
       copied:false,
       theme: localStorage.getItem('theme') || 'dark',
       sortable:null,
+      pipeline:null,
+      llmOutput:'',
+      loadingMessage:'',
       init(){
         this.loadSaved();
         this.applyTheme();
@@ -308,6 +320,31 @@
         navigator.clipboard.writeText(this.rendered());
         this.copied = true;
         setTimeout(() => this.copied = false, 1500);
+      },
+      async loadScript(src){
+        return new Promise((resolve, reject) => {
+          const s = document.createElement('script');
+          s.src = src;
+          s.onload = resolve;
+          s.onerror = reject;
+          document.head.appendChild(s);
+        });
+      },
+      async ensurePipeline(){
+        if(this.pipeline) return;
+        this.loadingMessage = 'Loading model...';
+        if(!window.transformers){
+          await this.loadScript('https://cdn.jsdelivr.net/npm/@xenova/transformers/dist/transformers.min.js');
+        }
+        this.pipeline = await window.transformers.pipeline('text-generation', 'Xenova/TinyLlama-1.1B-Chat-int4');
+        this.loadingMessage = '';
+      },
+      async runPrompt(){
+        await this.ensurePipeline();
+        this.loadingMessage = 'Generating...';
+        const result = await this.pipeline(this.rendered(), { max_new_tokens: 64 });
+        this.loadingMessage = '';
+        this.llmOutput = result[0].generated_text;
       },
       initSortable(){
         if(this.sortable) return;


### PR DESCRIPTION
## Summary
- enable running prompts locally with tiny model
- show loading state and display result
- document new LLM testing capability
- switch to TinyLlama model for in browser prompt testing

## Testing
- `git status --short`