### PR TITLE
Add offline LLM pipeline stub with fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -353,7 +353,15 @@
         try {
           if(!window.transformers){
             this.log('Loading transformers library...');
-            await this.loadScript('https://cdn.jsdelivr.net/npm/@xenova/transformers/dist/transformers.min.js');
+            try {
+              await this.loadScript('https://cdn.jsdelivr.net/npm/@xenova/transformers/dist/transformers.min.js');
+            } catch(e){
+              this.log('CDN load failed, using local stub.');
+              await this.loadScript('transformers_stub.js');
+            }
+          }
+          if(!window.transformers || !window.transformers.pipeline){
+            throw new Error('Transformers library unavailable');
           }
           this.pipeline = await window.transformers.pipeline('text-generation', 'Xenova/TinyLlama-1.1B-Chat-int4');
           this.log('Model loaded.');
@@ -367,6 +375,9 @@
       async runPrompt(){
         try {
           await this.ensurePipeline();
+          if(!this.pipeline){
+            throw new Error('Pipeline unavailable');
+          }
           this.loadingMessage = 'Generating...';
           this.log('Generating response...');
           const result = await this.pipeline(this.rendered(), { max_new_tokens: 64 });

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+node tests/test_stub.js

--- a/tests/test_stub.js
+++ b/tests/test_stub.js
@@ -1,0 +1,10 @@
+const assert = require('assert');
+const transformers = require('../transformers_stub');
+
+(async () => {
+  const pipeline = await transformers.pipeline('text-generation', 'model');
+  const res = await pipeline('hello');
+  assert(Array.isArray(res), 'Result should be array');
+  assert(res[0].generated_text.includes('hello'), 'Output should contain input text');
+  console.log('All tests passed');
+})();

--- a/transformers_stub.js
+++ b/transformers_stub.js
@@ -1,0 +1,13 @@
+(function(global){
+  async function pipeline(task, model){
+    return async function(text, options){
+      return [{ generated_text: `[stub:${model}] ${text}` }];
+    };
+  }
+  const transformers = { pipeline };
+  if (typeof module !== 'undefined' && module.exports){
+    module.exports = transformers;
+  } else {
+    global.transformers = transformers;
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : window);


### PR DESCRIPTION
## Summary
- handle missing transformers library by falling back to a local stub in `ensurePipeline`
- guard against absent pipeline in `runPrompt`
- provide `transformers_stub.js` that mimics the transformers API
- add simple Node-based unit test for the stub

## Testing
- `tests/run-tests.sh`