### PR TITLE
Fix LLM fallback loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -361,6 +361,10 @@
             }
           }
           if(!window.transformers || !window.transformers.pipeline){
+            this.log('CDN library missing pipeline, using local stub.');
+            await this.loadScript('transformers_stub.js');
+          }
+          if(!window.transformers || !window.transformers.pipeline){
             throw new Error('Transformers library unavailable');
           }
           this.pipeline = await window.transformers.pipeline('text-generation', 'Xenova/TinyLlama-1.1B-Chat-int4');


### PR DESCRIPTION
## Summary
- ensure the browser falls back to `transformers_stub.js` if the CDN library loads but does not expose a pipeline

## Testing
- `bash tests/run-tests.sh`