### PR TITLE
Restore real LLM integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ A lightweight client-side web app for building and previewing prompt templates f
 
 Open `index.html` in a browser. No build step or server is required.
 
-Click the play button next to the token count to run your prompt through the included quantized Llama model. The first run downloads the model files, so it may take a moment.
+Click the play button next to the token count to run your prompt through a small GPT style model. The first run fetches the `@xenova/transformers` library from a CDN (jsDelivr or unpkg) and downloads the TinyLlama weights, so generation may take a moment.
 
 Feel free to customize the default template and styling.

--- a/index.html
+++ b/index.html
@@ -350,19 +350,21 @@
         if(this.pipeline) return;
         this.log('Initializing pipeline...');
         this.loadingMessage = 'Loading model...';
+        const sources = [
+          'https://cdn.jsdelivr.net/npm/@xenova/transformers/dist/transformers.min.js',
+          'https://unpkg.com/@xenova/transformers/dist/transformers.min.js'
+        ];
         try {
           if(!window.transformers){
-            this.log('Loading transformers library...');
-            try {
-              await this.loadScript('https://cdn.jsdelivr.net/npm/@xenova/transformers/dist/transformers.min.js');
-            } catch(e){
-              this.log('CDN load failed, using local stub.');
-              await this.loadScript('transformers_stub.js');
+            for(const src of sources){
+              try {
+                this.log('Loading transformers library from ' + src + '...');
+                await this.loadScript(src);
+                if(window.transformers && window.transformers.pipeline) break;
+              } catch(e){
+                this.log('Failed to load from ' + src + ': ' + e);
+              }
             }
-          }
-          if(!window.transformers || !window.transformers.pipeline){
-            this.log('CDN library missing pipeline, using local stub.');
-            await this.loadScript('transformers_stub.js');
           }
           if(!window.transformers || !window.transformers.pipeline){
             throw new Error('Transformers library unavailable');


### PR DESCRIPTION
## Summary
- attempt to load `@xenova/transformers` from multiple CDNs
- remove automatic fallback to stub
- update README usage instructions

## Testing
- `bash tests/run-tests.sh`