### PR TITLE
Improve offline fallback for model loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ A lightweight client-side web app for building and previewing prompt templates f
 
 Open `index.html` in a browser. No build step or server is required.
 
-Click the play button next to the token count to run your prompt through a small GPT style model. The first run fetches the `@xenova/transformers` library from a CDN (jsDelivr or unpkg) and downloads the TinyLlama weights, so generation may take a moment.
+Click the play button next to the token count to run your prompt through a small GPT style model. The app tries to load the `transformers` library from a CDN and will fall back to the included `transformers_stub.js` if the network request fails. The default model uses `openlm-research/open_llama_3b`.
 
 Feel free to customize the default template and styling.

--- a/index.html
+++ b/index.html
@@ -352,15 +352,20 @@
         this.loadingMessage = 'Loading model...';
         const sources = [
           'https://cdn.jsdelivr.net/npm/@xenova/transformers/dist/transformers.min.js',
-          'https://unpkg.com/@xenova/transformers/dist/transformers.min.js'
+          'https://unpkg.com/@xenova/transformers/dist/transformers.min.js',
+          './transformers_stub.js'
         ];
+        let loadedFrom = null;
         try {
           if(!window.transformers){
             for(const src of sources){
               try {
                 this.log('Loading transformers library from ' + src + '...');
                 await this.loadScript(src);
-                if(window.transformers && window.transformers.pipeline) break;
+                if(window.transformers && window.transformers.pipeline){
+                  loadedFrom = src;
+                  break;
+                }
               } catch(e){
                 this.log('Failed to load from ' + src + ': ' + e);
               }
@@ -369,7 +374,10 @@
           if(!window.transformers || !window.transformers.pipeline){
             throw new Error('Transformers library unavailable');
           }
-          this.pipeline = await window.transformers.pipeline('text-generation', 'Xenova/TinyLlama-1.1B-Chat-int4');
+          this.pipeline = await window.transformers.pipeline('text-generation', 'openlm-research/open_llama_3b');
+          if(loadedFrom){
+            this.log('Transformers loaded from ' + loadedFrom + '.');
+          }
           this.log('Model loaded.');
         } catch(err){
           this.log('Pipeline load failed: ' + err);


### PR DESCRIPTION
## Summary
- make transformer lib load fallback to local stub if CDN fails
- use openllama 3b model by default
- document fallback behaviour in README

## Testing
- `./tests/run-tests.sh`