### PR TITLE
Fix local LLM pipeline generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ A lightweight client-side web app for building and previewing prompt templates f
 
 Open `index.html` in a browser. No build step or server is required.
 
-Click the play button next to the token count to run your prompt through a lightweight LLaMA model powered by `llama.cpp` compiled to WebAssembly. The runtime is loaded from `/lib/llama-cpp.wasm` and the quantized weights from `/models/ggml-7b-q4.bin`.
+Click the play button next to the token count to run your prompt through a lightweight LLaMA model powered by `llama.cpp` compiled to WebAssembly. The runtime and model are loaded at runtime from public CDNs.
 
-Open DevTools → Network and confirm that both files return **200** and are served with `application/octet-stream`.
+Open DevTools → Network and confirm that the WASM and model files return **200**.
 
 Feel free to customize the default template and styling.

--- a/index.html
+++ b/index.html
@@ -344,8 +344,8 @@
         try {
           const { createLLamaContext } = await import('https://esm.sh/llama-cpp-wasm@0.1.2');
           this.llamaCtx = await createLLamaContext({
-            wasmURL: '/lib/llama-cpp.wasm',
-            modelURL: '/models/ggml-7b-q4.bin',
+            wasmURL: 'https://esm.sh/llama-cpp-wasm@0.1.2/llama-cpp.wasm',
+            modelURL: 'https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.q4_0.gguf',
             nThreads: navigator.hardwareConcurrency || 4
           });
           this.log('Model loaded.');

--- a/lib/llama-cpp.wasm
+++ b/lib/llama-cpp.wasm
@@ -1,1 +1,0 @@
-placeholder wasm

--- a/models/ggml-7b-q4.bin
+++ b/models/ggml-7b-q4.bin
@@ -1,1 +1,0 @@
-placeholder model

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "prompteditor",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node test/integration.js"
+  }
+}

--- a/test/integration.js
+++ b/test/integration.js
@@ -3,8 +3,8 @@ import { createLLamaContext } from 'https://esm.sh/llama-cpp-wasm@0.1.2';
 async function run() {
   try {
     const ctx = await createLLamaContext({
-      wasmURL: '../lib/llama-cpp.wasm',
-      modelURL: '../models/ggml-7b-q4.bin',
+      wasmURL: 'https://esm.sh/llama-cpp-wasm@0.1.2/llama-cpp.wasm',
+      modelURL: 'https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.q4_0.gguf',
       nThreads: 1
     });
     const result = await ctx.run({ prompt: 'Hello,', nPredict: 1 });


### PR DESCRIPTION
## Notes
- remove local placeholder runtime
- fetch llama WASM and model from public CDNs
- update integration test to match new URLs

## Testing
- `npm test` *(fails: Node can't import https URLs)*