### PR TITLE
Fix CORS issues by loading llama runtime via jsDelivr

### DIFF
--- a/index.html
+++ b/index.html
@@ -343,8 +343,9 @@
         this.log('Initializing LLaMA context...');
         this.loadingMessage = 'Loading model...';
         try {
-          const { createLLamaContext } = await import('https://tangledgroup.github.io/llama-cpp-wasm/dist/llama-mt/llama.js');
+          const { createLLamaContext } = await import('https://cdn.jsdelivr.net/gh/tangledgroup/llama-cpp-wasm@main/dist/llama-mt/llama.js');
           this.llamaCtx = await createLLamaContext({
+            wasmURL: 'https://cdn.jsdelivr.net/gh/tangledgroup/llama-cpp-wasm@main/dist/llama-mt/llama-cpp.wasm',
             modelURL: 'https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.q4_0.gguf',
             nThreads: navigator.hardwareConcurrency || 4
           });

--- a/test/integration.js
+++ b/test/integration.js
@@ -1,8 +1,9 @@
-import { createLLamaContext } from 'https://tangledgroup.github.io/llama-cpp-wasm/dist/llama-mt/llama.js';
+import { createLLamaContext } from 'https://cdn.jsdelivr.net/gh/tangledgroup/llama-cpp-wasm@main/dist/llama-mt/llama.js';
 
 async function run() {
   try {
     const ctx = await createLLamaContext({
+      wasmURL: 'https://cdn.jsdelivr.net/gh/tangledgroup/llama-cpp-wasm@main/dist/llama-mt/llama-cpp.wasm',
       modelURL: 'https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.q4_0.gguf',
       nThreads: 1
     });


### PR DESCRIPTION
## Summary
- load llama-cpp-wasm from jsDelivr so CORS headers are present
- pass explicit wasm URL when creating llama context

## Testing
- `npm test` *(fails: ERR_UNSUPPORTED_ESM_URL_SCHEME)*