### PR TITLE
Fix collapse usage and model URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,12 +10,6 @@
   </script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
-  <script defer src="https://unpkg.com/@alpinejs/collapse@3.x.x/dist/cdn.min.js"></script>
-  <script>
-    document.addEventListener('alpine:init', () => {
-      Alpine.plugin(window.AlpineCollapse)
-    })
-  </script>
   <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" />
 </head>
@@ -87,7 +81,7 @@
                 <input x-model="section.endTag" placeholder="End tag" class="w-1/3 p-1 bg-neutral-900 rounded focus:outline-none" :class="theme === 'light' ? 'bg-neutral-200 text-black' : 'bg-neutral-900'">
                 <button @click="removeSection(idx)" class="px-2 bg-neutral-700 rounded" :class="theme === 'light' ? 'bg-neutral-300 text-black' : 'bg-neutral-700'" aria-label="Remove section"><i class="fa-solid fa-xmark"></i></button>
               </div>
-              <div x-show="!section.collapsed" x-collapse.duration.300>
+              <div x-show="!section.collapsed" x-transition.duration.300>
                 <textarea x-model="section.content" rows="3" class="w-full p-2 mt-2 bg-neutral-900 rounded focus:outline-none" placeholder="Section content" :class="theme === 'light' ? 'bg-neutral-200 text-black' : 'bg-neutral-900'"></textarea>
               </div>
             </div>
@@ -351,7 +345,7 @@
         try {
           const { Wllama } = await import('https://cdn.jsdelivr.net/npm/@wllama/wllama@2.3.1/esm/index.js');
           const wasmURL = 'https://cdn.jsdelivr.net/npm/@wllama/wllama@2.3.1/esm/single-thread/wllama.wasm';
-          const modelURL = 'https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.q4_0.gguf?download=1';
+          const modelURL = 'https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.q4_0.gguf';
           this.log('Instantiating WASM from ' + wasmURL);
           const llama = new Wllama({ 'single-thread/wllama.wasm': wasmURL });
           this.log('Loading model from ' + modelURL);

--- a/test/integration.js
+++ b/test/integration.js
@@ -3,7 +3,7 @@ import { Wllama } from 'https://cdn.jsdelivr.net/npm/@wllama/wllama@2.3.1/esm/in
 async function run() {
   try {
     const wasmURL = 'https://cdn.jsdelivr.net/npm/@wllama/wllama@2.3.1/esm/single-thread/wllama.wasm';
-    const modelURL = 'https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.q4_0.gguf?download=1';
+    const modelURL = 'https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.q4_0.gguf';
     const llama = new Wllama({ 'single-thread/wllama.wasm': wasmURL });
     await llama.loadModelFromUrl(modelURL);
     const result = await llama.createCompletion('Hello,', { nPredict: 1 });


### PR DESCRIPTION
## Summary
- remove unused Alpine collapse plugin
- replace `x-collapse` with built-in `x-transition`
- fix TinyLlama model URL so it ends in `.gguf`

## Testing
- `npm test` *(fails: getaddrinfo ENOTFOUND cdn.jsdelivr.net)*