### PR TITLE
Fix model URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -345,7 +345,7 @@
         try {
           const { Wllama } = await import('https://cdn.jsdelivr.net/npm/@wllama/wllama@2.3.1/esm/index.js');
           const wasmURL = 'https://cdn.jsdelivr.net/npm/@wllama/wllama@2.3.1/esm/single-thread/wllama.wasm';
-          const modelURL = 'https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.Q4_0.gguf?download=true';
+          const modelURL = 'https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.Q4_0.gguf';
           this.log('Instantiating WASM from ' + wasmURL);
           const llama = new Wllama({ 'single-thread/wllama.wasm': wasmURL });
           this.log('Loading model from ' + modelURL);

--- a/test/integration.js
+++ b/test/integration.js
@@ -3,7 +3,7 @@ import { Wllama } from 'https://cdn.jsdelivr.net/npm/@wllama/wllama@2.3.1/esm/in
 async function run() {
   try {
     const wasmURL = 'https://cdn.jsdelivr.net/npm/@wllama/wllama@2.3.1/esm/single-thread/wllama.wasm';
-    const modelURL = 'https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.Q4_0.gguf?download=true';
+    const modelURL = 'https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.Q4_0.gguf';
     const llama = new Wllama({ 'single-thread/wllama.wasm': wasmURL });
     await llama.loadModelFromUrl(modelURL);
     const result = await llama.createCompletion('Hello,', { nPredict: 1 });


### PR DESCRIPTION
## Summary
- update the Llama model URL to remove query parameters
- keep integration test in sync

## Testing
- `npm test` *(fails: getaddrinfo ENOTFOUND cdn.jsdelivr.net)*