### PR TITLE
Use non streaming completions

### DIFF
--- a/index.html
+++ b/index.html
@@ -371,12 +371,10 @@
           this.loadingMessage = 'Generating...';
           this.log('Generating response...');
           this.llmOutput = '';
-          for await (const chunk of this.llamaCtx.createCompletion(
+          this.llmOutput = await this.llamaCtx.createCompletion(
             this.rendered(),
             { nPredict: 64, temp: 0.7, top_k: 40 }
-          )) {
-            this.llmOutput += chunk;
-          }
+          );
           this.log('Generation complete.');
         } catch(err){
           this.log('Run error: ' + err);

--- a/test/integration.js
+++ b/test/integration.js
@@ -6,10 +6,7 @@ async function run() {
     const modelURL = 'https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.Q4_0.gguf';
     const llama = new Wllama({ 'single-thread/wllama.wasm': wasmURL });
     await llama.loadModelFromUrl(modelURL);
-    let out = '';
-    for await (const chunk of llama.createCompletion('Hello,', { nPredict: 1 })) {
-      out += chunk;
-    }
+    const out = await llama.createCompletion('Hello,', { nPredict: 1 });
     console.log('Generated token:', out);
   } catch (err) {
     console.error('Generation failed:', err);


### PR DESCRIPTION
## Summary
- simplify completion API usage in `runPrompt`
- update integration test to use non-streaming completion

## Testing
- `npm test` *(fails: getaddrinfo ENOTFOUND cdn.jsdelivr.net)*