### PR TITLE
Fix runPrompt generation bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -375,13 +375,14 @@
           }
           this.loadingMessage = 'Generating...';
           this.log('Generating response...');
-          this.llmOutput = '';
-          for await (const chunk of this.llamaCtx.createCompletion(
+
+          // One-shot completion without streaming
+          const responseText = await this.llamaCtx.createCompletion(
             this.rendered(),
             { nPredict: 64, temp: 0.7, topK: 40 }
-          )) {
-            this.llmOutput += chunk;
-          }
+          );
+
+          this.llmOutput = responseText;
           this.log('Generation complete.');
         } catch(err){
           this.log('Run error: ' + err);


### PR DESCRIPTION
## Summary
- switch runPrompt to use one-shot completion instead of async iterator

## Testing
- `npm test` *(fails: getaddrinfo ENOTFOUND cdn.jsdelivr.net)*