### PR TITLE
Add Gemma model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,9 @@ Click the play button next to the token count to run your prompt through a light
 Open DevTools → Network and confirm that the WASM and model files return **200**.
 
 Feel free to customize the default template and styling.
+
+### Testing Gemma Model
+
+The repository includes a small script `initWllamaGemma.js` and a test at
+`test/gemma.js` for loading the lighter Gemma model. Run `npm test` to execute
+both the default integration test and the Gemma test.

--- a/index.html
+++ b/index.html
@@ -345,13 +345,13 @@
         try {
           const { Wllama } = await import('https://cdn.jsdelivr.net/npm/@wllama/wllama@latest/esm/index.js');
           const wasmURL = 'https://cdn.jsdelivr.net/npm/@wllama/wllama@latest/esm/single-thread/wllama.wasm';
-          // Stream the TheBloke 3B model directly inside the worker
-          const modelRepo = 'TheBloke/rocket-3B-GGUF';
-          const modelFile = 'rocket-3b.Q4_K_M.gguf';
+          // Load the smaller Gemma model to reduce memory usage
+          const modelRepo = 'google/gemma-3-1b-it-qat-q4_0-gguf';
+          const modelFile = 'gemma-3-1b-it-qat-q4_0.gguf';
           this.log('Instantiating WASM from ' + wasmURL);
           const llama = new Wllama(
             { 'single-thread/wllama.wasm': wasmURL },
-            { parallelDownloads: 5, allowOffline: false }
+            { parallelDownloads: 1, allowOffline: false }
           );
           this.log('Loading model from ' + modelRepo + '/' + modelFile);
           await llama.loadModelFromHF(modelRepo, modelFile);

--- a/initWllamaGemma.js
+++ b/initWllamaGemma.js
@@ -1,0 +1,24 @@
+async function ensureLlamaContext() {
+  if (this.llamaCtx) return;
+  this.log('Initializing WLLama context…');
+  const wasmURL  = 'https://cdn.jsdelivr.net/npm/@wllama/wllama@latest/esm/single-thread/wllama.wasm';
+  const modelRepo = 'google/gemma-3-1b-it-qat-q4_0-gguf';          // [Gemma 3 1B Q4_0]
+  const modelFile = 'gemma-3-1b-it-qat-q4_0.gguf';
+
+  try {
+    const { Wllama } = await import('https://cdn.jsdelivr.net/npm/@wllama/wllama@latest/esm/index.js');
+    // force single-thread + serial downloads to avoid iOS OPFS bugs
+    const llama = new Wllama(
+      { 'single-thread/wllama.wasm': wasmURL },
+      { parallelDownloads: 1, allowOffline: false }
+    );
+
+    this.log('Loading model from ' + modelRepo + '/' + modelFile);
+    await llama.loadModelFromHF(modelRepo, modelFile);
+    this.llamaCtx = llama;
+    this.log('Model loaded.');
+  } catch(err) {
+    this.log('Context init failed: ' + err);
+    throw err;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "test": "node --experimental-network-imports test/integration.js"
+    "test": "node --experimental-network-imports test/integration.js && node --experimental-network-imports test/gemma.js"
   }
 }

--- a/test/gemma.js
+++ b/test/gemma.js
@@ -1,0 +1,26 @@
+import { Wllama } from 'https://cdn.jsdelivr.net/npm/@wllama/wllama@latest/esm/index.js';
+
+async function run() {
+  try {
+    const wasmURL = 'https://cdn.jsdelivr.net/npm/@wllama/wllama@latest/esm/single-thread/wllama.wasm';
+    const llama = new Wllama(
+      { 'single-thread/wllama.wasm': wasmURL },
+      { parallelDownloads: 1, allowOffline: false }
+    );
+    const modelRepo = 'google/gemma-3-1b-it-qat-q4_0-gguf';
+    const modelFile = 'gemma-3-1b-it-qat-q4_0.gguf';
+    await llama.loadModelFromHF(modelRepo, modelFile);
+    let out = '';
+    for await (const chunk of llama.createCompletion('Hello,', { nPredict: 1 })) {
+      out += chunk;
+    }
+    console.log('Generated token:', out);
+  } catch (err) {
+    console.error('Generation failed:', err);
+    if(err && err.stack){
+      console.error(err.stack);
+    }
+    process.exitCode = 1;
+  }
+}
+run();


### PR DESCRIPTION
## Summary
- tweak llama initialization to use the Gemma 3 1B Q4 model
- add `initWllamaGemma.js` helper
- add a Gemma integration test
- update README with Gemma notes
- run Gemma test along with existing integration test

## Testing
- `npm test` *(fails: getaddrinfo ENOTFOUND cdn.jsdelivr.net)*