### PR TITLE
Run model in web worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A lightweight client-side web app for building and previewing prompt templates f
 - Icon-based buttons for a compact interface.
 - Reorder sections via drag and drop.
 - Animated interactions with feedback when copying the rendered prompt.
-- Test prompts locally with a lightweight in-browser Llama model.
+- Test prompts locally with a lightweight in-browser Llama model executed inside a Web Worker.
 - Displays estimated token count for the rendered prompt.
 - Built-in starter templates for code assistants and document extraction.
 - Separate settings page to manage preferences.
@@ -22,7 +22,7 @@ A lightweight client-side web app for building and previewing prompt templates f
 
 Open `index.html` in a browser. No build step or server is required.
 
-Click the play button next to the token count to run your prompt through a lightweight LLaMA model powered by `llama.cpp` compiled to WebAssembly. The runtime and model are loaded at runtime from public CDNs.
+Click the play button next to the token count to run your prompt through a lightweight LLaMA model powered by `llama.cpp` compiled to WebAssembly. The runtime and model are loaded at runtime from public CDNs and the model executes inside a Web Worker.
 
 Open DevTools → Network and confirm that the WASM and model files return **200**.
 

--- a/index.html
+++ b/index.html
@@ -202,7 +202,7 @@
       copied:false,
       theme: localStorage.getItem('theme') || 'dark',
       sortable:null,
-      llamaCtx:null,
+      llamaWorker:null,
       llmOutput:'',
       loadingMessage:'',
       logs:[],
@@ -341,73 +341,68 @@
         });
       },
       async ensureLlamaContext(force){
-        if(this.llamaCtx && !force) return;
-        this.log('Initializing WLLama context...');
-        this.loadingMessage = 'Loading model...';
-        try {
-          const { Wllama } = await import('https://cdn.jsdelivr.net/npm/@wllama/wllama@latest/esm/index.js');
-          const wasmURL = 'https://cdn.jsdelivr.net/npm/@wllama/wllama@latest/esm/single-thread/wllama.wasm';
-          // Stream the TheBloke 3B model directly inside the worker
-          const modelRepo = 'TheBloke/rocket-3B-GGUF';
-          const modelFile = 'rocket-3b.Q4_K_M.gguf';
-          this.log('Instantiating WASM from ' + wasmURL);
-          const llama = new Wllama(
-            { 'single-thread/wllama.wasm': wasmURL },
-            { parallelDownloads: 5, allowOffline: false }
-          );
-          this.log('Loading model from ' + modelRepo + '/' + modelFile);
-          await llama.loadModelFromHF(modelRepo, modelFile);
-          this.llamaCtx = llama;
-          this.log('Model loaded.');
-        } catch(err){
-          this.log('Context init failed: ' + err);
-          if(err && err.stack){
-            this.log(err.stack);
-          }
-          throw err;
-        } finally {
-          this.loadingMessage = '';
+        if(this.llamaWorker && !force) return;
+        if(this.llamaWorker){
+          this.llamaWorker.terminate();
+          this.llamaWorker = null;
         }
+        this.log('Initializing WLLama worker...');
+        this.loadingMessage = 'Loading model...';
+        await new Promise((resolve, reject) => {
+          const worker = new Worker('llama-worker.js', { type: 'module' });
+          this.llamaWorker = worker;
+          const onMessage = e => {
+            const d = e.data;
+            if(d.type === 'init'){
+              worker.removeEventListener('message', onMessage);
+              this.log('Model loaded.');
+              resolve();
+            } else if(d.type === 'error'){
+              worker.removeEventListener('message', onMessage);
+              this.log('Context init failed: ' + d.message);
+              if(d.stack) this.log(d.stack);
+              reject(new Error(d.message));
+            }
+          };
+          worker.addEventListener('message', onMessage);
+          worker.postMessage({action:'init'});
+        });
+        this.loadingMessage = '';
       },
       async runPrompt(){
         let prompt = this.rendered();
         try {
           await this.ensureLlamaContext();
-          if(!this.llamaCtx){
-            throw new Error('Context unavailable');
+          if(!this.llamaWorker){
+            throw new Error('Worker unavailable');
           }
           this.loadingMessage = 'Generating...';
           this.log('Generating response...');
           this.log('Prompt length: ' + prompt.length);
 
-          const responseText = await this.llamaCtx.createCompletion(
-            prompt,
-            { nPredict: 64, temp: 0.7, topK: 40 }
-          );
-
-          this.llmOutput = responseText;
-          this.log('Generation complete.');
+          await new Promise((resolve, reject) => {
+            const worker = this.llamaWorker;
+            const onMessage = e => {
+              const d = e.data;
+              if(d.type === 'result'){
+                worker.removeEventListener('message', onMessage);
+                this.llmOutput = d.text;
+                this.log('Generation complete.');
+                resolve();
+              }else if(d.type === 'error'){
+                worker.removeEventListener('message', onMessage);
+                this.log('Generation error: ' + d.message);
+                if(d.stack) this.log(d.stack);
+                reject(new Error(d.message));
+              }
+            };
+            worker.addEventListener('message', onMessage);
+            worker.postMessage({action:'generate', prompt});
+          });
         } catch(err){
           this.log('Run error: ' + err);
           if(err && err.stack){
             this.log(err.stack);
-          }
-          if(err && err.name === 'DataCloneError'){
-            this.log('DataCloneError detected - resetting context and retrying');
-            try{
-              await this.ensureLlamaContext(true);
-              const retryText = await this.llamaCtx.createCompletion(
-                prompt,
-                { nPredict: 64, temp: 0.7, topK: 40 }
-              );
-              this.llmOutput = retryText;
-              this.log('Generation complete after retry.');
-            }catch(err2){
-              this.log('Retry failed: ' + err2);
-              if(err2 && err2.stack){
-                this.log(err2.stack);
-              }
-            }
           }
         } finally {
           this.loadingMessage = '';

--- a/llama-worker.js
+++ b/llama-worker.js
@@ -1,0 +1,28 @@
+self.addEventListener('message', async (e) => {
+  const { action, prompt } = e.data || {};
+  try {
+    if (action === 'init') {
+      if (self.llama) {
+        self.postMessage({ type: 'init' });
+        return;
+      }
+      const { Wllama } = await import('https://cdn.jsdelivr.net/npm/@wllama/wllama@latest/esm/index.js');
+      const wasmURL = 'https://cdn.jsdelivr.net/npm/@wllama/wllama@latest/esm/single-thread/wllama.wasm';
+      const llama = new Wllama({ 'single-thread/wllama.wasm': wasmURL }, { parallelDownloads: 5, allowOffline: false });
+      await llama.loadModelFromHF('TheBloke/rocket-3B-GGUF', 'rocket-3b.Q4_K_M.gguf');
+      self.llama = llama;
+      self.postMessage({ type: 'init' });
+    } else if (action === 'generate') {
+      if (!self.llama) {
+        throw new Error('Model not initialized');
+      }
+      let out = '';
+      for await (const chunk of self.llama.createCompletion(prompt, { nPredict: 64, temp: 0.7, topK: 40 })) {
+        out += chunk;
+      }
+      self.postMessage({ type: 'result', text: out });
+    }
+  } catch (err) {
+    self.postMessage({ type: 'error', message: String(err), stack: err && err.stack });
+  }
+});


### PR DESCRIPTION
## Summary
- execute llama.cpp via a dedicated `llama-worker.js`
- use the worker in `index.html` to avoid `DataCloneError`
- mention the worker in README

## Testing
- `npm test` *(fails: getaddrinfo ENOTFOUND cdn.jsdelivr.net)*

------
https://chatgpt.com/codex/tasks/task_b_683b056f83648327b0e9ba35c7049fcd