### PR TITLE
Fix WLLama worker init

### DIFF
--- a/llama-worker.js
+++ b/llama-worker.js
@@ -6,6 +6,12 @@ self.addEventListener('message', async (e) => {
         self.postMessage({ type: 'init' });
         return;
       }
+      // The @wllama/wllama ESM build expects a `document` global to
+      // determine its base URL. Web workers don't provide this by
+      // default, so create a minimal stub before importing the module.
+      if (typeof self.document === 'undefined') {
+        self.document = { currentScript: { src: self.location.href } };
+      }
       const { Wllama } = await import('https://cdn.jsdelivr.net/npm/@wllama/wllama@latest/esm/index.js');
       const wasmURL = 'https://cdn.jsdelivr.net/npm/@wllama/wllama@latest/esm/single-thread/wllama.wasm';
       const llama = new Wllama({ 'single-thread/wllama.wasm': wasmURL }, { parallelDownloads: 5, allowOffline: false });

--- a/test/integration.js
+++ b/test/integration.js
@@ -1,3 +1,9 @@
+// The ESM bundle expects a browser-like `document` global to resolve
+// resource URLs. Provide a minimal stub when running under Node.
+if (typeof globalThis.document === 'undefined') {
+  globalThis.document = { currentScript: { src: import.meta.url } };
+}
+
 import { Wllama } from 'https://cdn.jsdelivr.net/npm/@wllama/wllama@latest/esm/index.js';
 
 async function run() {


### PR DESCRIPTION
## Summary
- stub `document` global when importing WLLama in the worker
- do the same for the integration test so Node can import the module

## Testing
- `npm test` *(fails: getaddrinfo ENOTFOUND cdn.jsdelivr.net)*

------
https://chatgpt.com/codex/tasks/task_b_683b08491f6083278325294c573b98d8