### PR TITLE
Handle non-iterable completion output

### DIFF
--- a/llama-worker.js
+++ b/llama-worker.js
@@ -25,8 +25,17 @@ self.addEventListener('message', async (e) => {
         throw new Error('Model not initialized');
       }
       let out = '';
-      for await (const chunk of self.llama.createCompletion(prompt, { nPredict: 64, temp: 0.7, topK: 40 })) {
-        out += chunk;
+      const result = self.llama.createCompletion(prompt, {
+        nPredict: 64,
+        temp: 0.7,
+        topK: 40
+      });
+      if (result && typeof result[Symbol.asyncIterator] === 'function') {
+        for await (const chunk of result) {
+          out += chunk;
+        }
+      } else {
+        out += await result;
       }
       self.postMessage({ type: 'result', text: out });
     }


### PR DESCRIPTION
## Summary
- support future WLLama API that may return a promise instead of an async iterator when generating text

## Testing
- `npm test` *(fails: getaddrinfo ENOTFOUND cdn.jsdelivr.net)*

------
https://chatgpt.com/codex/tasks/task_b_683b0b82f3c88327940ce1bec5e03136