### PR TITLE
Increase generation token limit CHECKPOINT model works

### DIFF
--- a/llama-worker.js
+++ b/llama-worker.js
@@ -35,7 +35,7 @@ self.addEventListener('message', async (e) => {
       log('Creating completion...');
       let out = '';
       let result = self.llama.createCompletion(prompt, {
-        nPredict: 64,
+        nPredict: 256,
         temp: 0.7,
         topK: 40
       });


### PR DESCRIPTION
## Summary
- increase max predicted tokens from 64 to 256

## Testing
- `npm test --silent` *(fails: getaddrinfo ENOTFOUND cdn.jsdelivr.net)*

------
https://chatgpt.com/codex/tasks/task_b_683b109d2ee88327b055cc35533e32db