### PR TITLE
Add sliders for Llama parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A lightweight client-side web app for building and previewing prompt templates f
 - Displays estimated token count for the rendered prompt.
 - Built-in starter templates for code assistants and document extraction.
 - Separate settings page to manage preferences.
+- Control generation parameters like max tokens, temperature and top-K via sliders, saved in local storage.
 - Upload files and automatically capture their text in a `[files]` section.
 
 ## Usage

--- a/index.html
+++ b/index.html
@@ -201,6 +201,11 @@
       showTemplateModal:false,
       copied:false,
       theme: localStorage.getItem('theme') || 'dark',
+      modelParams:{
+        nPredict: parseInt(localStorage.getItem('nPredict')) || 256,
+        temp: parseFloat(localStorage.getItem('temp')) || 0.7,
+        topK: parseInt(localStorage.getItem('topK')) || 40
+      },
       sortable:null,
       llamaWorker:null,
       llmOutput:'',
@@ -399,7 +404,7 @@
               }
             };
             worker.addEventListener('message', onMessage);
-            worker.postMessage({action:'generate', prompt});
+            worker.postMessage({action:'generate', prompt, params:this.modelParams});
           });
         } catch(err){
           this.log('Run error: ' + err);

--- a/llama-worker.js
+++ b/llama-worker.js
@@ -13,7 +13,7 @@ function log(message) {
 }
 
 self.addEventListener('message', async (e) => {
-  const { action, prompt } = e.data || {};
+  const { action, prompt, params } = e.data || {};
   try {
     if (action === 'init') {
       if (self.llama) {
@@ -33,12 +33,14 @@ self.addEventListener('message', async (e) => {
         throw new Error('Model not initialized');
       }
       log('Creating completion...');
-      let out = '';
-      let result = self.llama.createCompletion(prompt, {
+      const opts = {
         nPredict: 256,
         temp: 0.7,
-        topK: 40
-      });
+        topK: 40,
+        ...(params || {})
+      };
+      let out = '';
+      let result = self.llama.createCompletion(prompt, opts);
 
       if (result && typeof result.then === 'function') {
         log('createCompletion returned a Promise');

--- a/settings.html
+++ b/settings.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="h-full" x-data="themeManager()" x-init="initTheme()">
+<html lang="en" class="h-full" x-data="settingsManager()" x-init="initSettings()">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -18,30 +18,54 @@
       <a href="index.html" class="p-2" aria-label="Home"><i class="fa-solid fa-house"></i></a>
     </nav>
   </header>
-  <div class="bg-neutral-900 rounded-lg shadow-lg p-6 w-60 mx-auto transition-colors" :class="theme === 'light' ? 'bg-white text-black' : 'bg-neutral-900 text-white'">
+  <div class="bg-neutral-900 rounded-lg shadow-lg p-6 w-72 mx-auto transition-colors" :class="theme === 'light' ? 'bg-white text-black' : 'bg-neutral-900 text-white'">
     <h1 class="text-xl font-bold mb-4 text-center">Settings</h1>
     <label class="flex items-center space-x-2 mb-4">
-      <input type="checkbox" @change="toggleTheme()" :checked="theme === 'light'">
+      <input type="checkbox" @change="toggleTheme(); saveSettings()" :checked="theme === 'light'">
       <span>Light Mode</span>
     </label>
+
+    <div class="mb-4">
+      <label class="block text-sm">Max Tokens: <span x-text="nPredict"></span></label>
+      <input type="range" min="32" max="512" step="1" x-model.number="nPredict" @input="saveSettings()" class="w-full">
+    </div>
+
+    <div class="mb-4">
+      <label class="block text-sm">Temperature: <span x-text="temp.toFixed(2)"></span></label>
+      <input type="range" min="0" max="1" step="0.01" x-model.number="temp" @input="saveSettings()" class="w-full">
+    </div>
+
+    <div class="mb-4">
+      <label class="block text-sm">Top&nbsp;K: <span x-text="topK"></span></label>
+      <input type="range" min="1" max="100" step="1" x-model.number="topK" @input="saveSettings()" class="w-full">
+    </div>
+
     <a href="index.html" class="underline text-sm">Back</a>
   </div>
 
 <script>
-function themeManager(){
+function settingsManager(){
   return {
     theme: localStorage.getItem('theme') || 'dark',
-    initTheme(){
+    nPredict: parseInt(localStorage.getItem('nPredict')) || 256,
+    temp: parseFloat(localStorage.getItem('temp')) || 0.7,
+    topK: parseInt(localStorage.getItem('topK')) || 40,
+    initSettings(){
       this.applyTheme();
     },
     toggleTheme(){
       this.theme = this.theme === 'dark' ? 'light' : 'dark';
-      this.applyTheme();
     },
     applyTheme(){
       document.documentElement.classList.remove('light','dark');
       document.documentElement.classList.add(this.theme);
+    },
+    saveSettings(){
       localStorage.setItem('theme', this.theme);
+      localStorage.setItem('nPredict', this.nPredict);
+      localStorage.setItem('temp', this.temp);
+      localStorage.setItem('topK', this.topK);
+      this.applyTheme();
     }
   }
 }


### PR DESCRIPTION
## Summary
- allow configuration of generation parameters in **settings.html**
- store chosen parameters in local storage
- send configured parameters to the model
- document new feature in README

## Testing
- `npm test` *(fails: getaddrinfo ENOTFOUND cdn.jsdelivr.net)*

------
https://chatgpt.com/codex/tasks/task_b_683b138c7a28832793b26eac7c17c8ac