### PR TITLE
Increase llama context size

### DIFF
--- a/llama-worker.js
+++ b/llama-worker.js
@@ -24,7 +24,11 @@ self.addEventListener('message', async (e) => {
       const { Wllama } = await import('https://cdn.jsdelivr.net/npm/@wllama/wllama@latest/esm/index.js');
       const wasmURL = 'https://cdn.jsdelivr.net/npm/@wllama/wllama@latest/esm/single-thread/wllama.wasm';
       const llama = new Wllama({ 'single-thread/wllama.wasm': wasmURL }, { parallelDownloads: 5, allowOffline: false });
-      await llama.loadModelFromHF('TheBloke/rocket-3B-GGUF', 'rocket-3b.Q4_K_M.gguf');
+      await llama.loadModelFromHF(
+        'TheBloke/rocket-3B-GGUF',
+        'rocket-3b.Q4_K_M.gguf',
+        { nCtx: 4096 }
+      );
       self.llama = llama;
       log('Model ready.');
       self.postMessage({ type: 'init' });

--- a/test/integration.js
+++ b/test/integration.js
@@ -15,7 +15,8 @@ async function run() {
     );
     await llama.loadModelFromHF(
       'TheBloke/rocket-3B-GGUF',
-      'rocket-3b.Q4_K_M.gguf'
+      'rocket-3b.Q4_K_M.gguf',
+      { nCtx: 4096 }
     );
     let out = '';
     for await (const chunk of llama.createCompletion('Hello,', { nPredict: 1 })) {


### PR DESCRIPTION
## Summary
- bump llama context window to 4096 tokens when loading the model

## Testing
- `npm test` *(fails: getaddrinfo ENOTFOUND cdn.jsdelivr.net)*

------
https://chatgpt.com/codex/tasks/task_b_683b276a4160832793f9154a5f89b49e