### PR TITLE
Improve default experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ Click the play button next to the token count to run your prompt through a light
 
 Open DevTools → Network and confirm that the WASM and model files return **200**.
 
-Feel free to customize the default template and styling.
+The page initially loads with a sample task that asks the model to describe what a Cedar tree looks like, so you can try it out immediately. Feel free to customize the default template and styling.

--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
         <div class="flex items-center space-x-2">
           <span class="text-xs text-neutral-400" x-text="'Tokens: ' + tokenCount()"></span>
           <button @click="copyRender" class="px-2 bg-neutral-700 rounded" :class="theme === 'light' ? 'bg-neutral-300 text-black' : 'bg-neutral-700'" aria-label="Copy"><i class="fa-solid fa-copy"></i></button>
-          <button @click="runPrompt" class="px-2 bg-neutral-700 rounded" :class="theme === 'light' ? 'bg-neutral-300 text-black' : 'bg-neutral-700'" aria-label="Run"><i class="fa-solid fa-play"></i></button>
+          <button @click="runPrompt" class="px-2 border border-green-500 text-green-500 rounded" :class="theme === 'light' ? 'bg-white' : 'bg-neutral-900'" aria-label="Run"><i class="fa-solid fa-play"></i></button>
           <span x-show="copied" x-transition.opacity.scale.duration.300 class="text-green-400 text-xs ml-2">Copied!</span>
           <span x-show="loadingMessage" class="text-xs text-neutral-400 ml-2 flex items-center space-x-1" x-cloak>
             <i class="fa-solid fa-spinner animate-spin"></i>
@@ -187,7 +187,8 @@
         }
       },
       sections: addAnimFlag([
-        {startTag:'[system]', endTag:'[/system]', autoEndTag:'[/system]', content:'You are a helpful {{name}} with extensive knowledge in {{industry}}.'}
+        {startTag:'[system]', endTag:'[/system]', autoEndTag:'[/system]', content:'You are a helpful {{name}} with extensive knowledge in {{industry}}.'},
+        {startTag:'[task]', endTag:'[/task]', autoEndTag:'[/task]', content:'describe what a Cedar tree looks like.'}
       ]),
       entries: addAnimFlag([
         {key:'name', value:'bot'},


### PR DESCRIPTION
## Summary
- show a starter task that asks about Cedar trees
- make the play button green to stand out
- document the sample task in the README

## Testing
- `npm test` *(fails: getaddrinfo ENOTFOUND cdn.jsdelivr.net)*

------
https://chatgpt.com/codex/tasks/task_b_683b3011bb348327a2c0609b948c623d